### PR TITLE
Only split the avatarUrl if it is not empty

### DIFF
--- a/app/src/main/java/org/ligi/peepdroid/PeepViewHolder.kt
+++ b/app/src/main/java/org/ligi/peepdroid/PeepViewHolder.kt
@@ -1,6 +1,7 @@
 package org.ligi.peepdroid
 
 import android.support.v7.widget.RecyclerView
+import android.text.TextUtils.isEmpty
 import android.text.format.DateUtils
 import android.text.util.Linkify
 import android.view.LayoutInflater
@@ -27,9 +28,10 @@ class PeepViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
         val asDate = Date(peep.timestamp * 1000)
         view.peep_time_text.text = DateUtils.getRelativeTimeSpanString(asDate.time, Calendar.getInstance().timeInMillis, DateUtils.MINUTE_IN_MILLIS)
-
-        val avatarSplit = peep.avatarUrl.split(":")
-        UrlImageViewHelper.setUrlDrawable(view.avatar_image, "https://peepeth.s3-us-west-1.amazonaws.com/images/avatars/" + avatarSplit[1] + "/small." + avatarSplit[2])
+        if (!isEmpty(peep.avatarUrl)) {
+            val avatarSplit = peep.avatarUrl.split(":")
+            UrlImageViewHelper.setUrlDrawable(view.avatar_image, "https://peepeth.s3-us-west-1.amazonaws.com/images/avatars/" + avatarSplit[1] + "/small." + avatarSplit[2])
+        }
 
         if (peep.parent != null) {
             val parent = LayoutInflater.from(view.context).inflate(R.layout.peep, view.parent_container, false)


### PR DESCRIPTION
The app crashed with an IndexOutOfBoundsException when avataUrl was the empty String. Now the Avatar is just empty. Maybe a default avatar would be better?